### PR TITLE
Added the pruning based on time

### DIFF
--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -3,7 +3,7 @@ import scipy.stats as sp
 from copy import deepcopy
 
 from .CellVar import CellVar
-from .StateDistribution import die_prune_rule
+from .StateDistribution import assign_times, die_prune_rule
 
 
 # temporary style guide:
@@ -99,12 +99,14 @@ class LineageTree:
             self.output_list_of_gens = self.pruned_list_of_gens
             self.output_leaves_idx = self.pruned_leaves_idx
             self.output_leaves = self.pruned_leaves
+            assign_times(self)
         else:
             self.output_lineage = self.full_lin_list
             self.output_max_gen = self.full_max_gen
             self.output_list_of_gens = self.full_list_of_gens
             self.output_leaves_idx = self.full_leaves_idx
             self.output_leaves = self.full_leaves
+            assign_times(self)
 
     def __len__(self, prune_boolean):
         if prune_boolean:

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -102,14 +102,12 @@ class LineageTree:
             self.output_list_of_gens = self.pruned_list_of_gens
             self.output_leaves_idx = self.pruned_leaves_idx
             self.output_leaves = self.pruned_leaves
-            assign_times(self)
         else:
             self.output_lineage = self.full_lin_list
             self.output_max_gen = self.full_max_gen
             self.output_list_of_gens = self.full_list_of_gens
             self.output_leaves_idx = self.full_leaves_idx
             self.output_leaves = self.full_leaves
-            assign_times(self)
 
     def __len__(self, prune_boolean):
         if prune_boolean:
@@ -151,13 +149,17 @@ class LineageTree:
         return self.full_lin_list
 
     def _prune_lineage(self):
-        """ This function removes those cells that are intended to be remove from the full binary tree based on emissions.
-        It takes in LineageTree object, walks through all the cells in the full binary tree, applies the pruning to each cell that is supposed to be removed, and returns the pruned list of cells.
+        """ This function removes those cells that are intended to be remove 
+        from the full binary tree based on emissions.
+        It takes in LineageTree object, walks through all the cells in the full binary tree, 
+        applies the pruning to each cell that is supposed to be removed, 
+        and returns the pruned list of cells.
         """
+        assign_times(self)
         self.pruned_lin_list = deepcopy(self.full_lin_list)
         for cell in self.pruned_lin_list:
             if self.prune_condition == 'both':
-                if die_prune_rule(cell) and time_prune_rule(cell, self.desired_experiment_time):
+                if die_prune_rule(cell) or time_prune_rule(cell, self.desired_experiment_time):
                     _, _, self.pruned_lin_list = find_two_subtrees(
                         cell, self.pruned_lin_list)
                     cell.left = None

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -3,7 +3,7 @@ import scipy.stats as sp
 from copy import deepcopy
 
 from .CellVar import CellVar
-from .StateDistribution import prune_rule
+from .StateDistribution import die_prune_rule
 
 
 # temporary style guide:

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -50,7 +50,7 @@ class LineageTree:
         assert pi_num_states == T_num_states == E_num_states, "The number of states in your input Markov probability parameters are mistmatched. Please check that the dimensions and states match. "
         self.num_states = pi_num_states
         self.desired_experiment_time = desired_experiment_time
-        self.prune_condition = prune_condition # string for prune condition
+        self.prune_condition = prune_condition  # string for prune condition
         self.lineage_stats = []
 
         for state in range(self.num_states):
@@ -79,7 +79,7 @@ class LineageTree:
         # 'time' - prune based on the length of the experiment
         # 'both' - prune based on both the 'die' and 'time' conditions
         self.prune_condition = prune_condition
-        
+
         # this governs whether or not the pruned or the
         # the unpruned lineage is used in the analysis
         self.prune_boolean = prune_boolean
@@ -149,10 +149,10 @@ class LineageTree:
         return self.full_lin_list
 
     def _prune_lineage(self):
-        """ This function removes those cells that are intended to be remove 
+        """ This function removes those cells that are intended to be remove
         from the full binary tree based on emissions.
-        It takes in LineageTree object, walks through all the cells in the full binary tree, 
-        applies the pruning to each cell that is supposed to be removed, 
+        It takes in LineageTree object, walks through all the cells in the full binary tree,
+        applies the pruning to each cell that is supposed to be removed,
         and returns the pruned list of cells.
         """
         assign_times(self)
@@ -171,7 +171,7 @@ class LineageTree:
                         cell, self.pruned_lin_list)
                     cell.left = None
                     cell.right = None
-                    assert cell._isLeaf()          
+                    assert cell._isLeaf()
             elif self.prune_condition == 'time':
                 if time_prune_rule(cell, self.desired_experiment_time):
                     _, _, self.pruned_lin_list = find_two_subtrees(
@@ -278,11 +278,11 @@ class LineageTree:
         return parent_holder
 
     def __repr__(self):
-        """ 
+        """
         This function is used to get string representation of an object, used for debugging and development.
-        Represents the information about the lineage that the user has created, 
+        Represents the information about the lineage that the user has created,
         like whether the tree is pruned or is a full tree;
-        and for both of the options it prints the number of states, 
+        and for both of the options it prints the number of states,
         the number of cells in the states, the total number of cells.
         """
         s1 = ""
@@ -315,7 +315,7 @@ class LineageTree:
     def __str__(self):
         """
         This function is used to get string representation of an object,
-        used for showing the results to the user. 
+        used for showing the results to the user.
         """
         return self.__repr__()
 

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -151,7 +151,7 @@ class LineageTree:
         """
         self.pruned_lin_list = deepcopy(self.full_lin_list)
         for cell in self.pruned_lin_list:
-            if prune_rule(cell):
+            if die_prune_rule(cell):
                 _, _, self.pruned_lin_list = find_two_subtrees(
                     cell, self.pruned_lin_list)
                 cell.left = None

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -3,7 +3,7 @@ import scipy.stats as sp
 from copy import deepcopy
 
 from .CellVar import CellVar
-from .StateDistribution import assign_times, die_prune_rule, time_prune_rule
+from .StateDistribution import assign_times, fate_prune_rule, time_prune_rule
 
 
 # temporary style guide:
@@ -77,7 +77,7 @@ class LineageTree:
         # this is given by the user:
         # 'fate' - prune based on the fate of the cell
         # 'time' - prune based on the length of the experiment
-        # 'both' - prune based on both the 'die' and 'time' conditions
+        # 'both' - prune based on both the 'fate' and 'time' conditions
         self.prune_condition = prune_condition
 
         # this governs whether or not the pruned or the
@@ -159,14 +159,14 @@ class LineageTree:
         self.pruned_lin_list = deepcopy(self.full_lin_list)
         for cell in self.pruned_lin_list:
             if self.prune_condition == 'both':
-                if die_prune_rule(cell) or time_prune_rule(cell, self.desired_experiment_time):
+                if fate_prune_rule(cell) or time_prune_rule(cell, self.desired_experiment_time):
                     _, _, self.pruned_lin_list = find_two_subtrees(
                         cell, self.pruned_lin_list)
                     cell.left = None
                     cell.right = None
                     assert cell._isLeaf()
-            elif self.prune_condition == 'die':
-                if die_prune_rule(cell):
+            elif self.prune_condition == 'fate':
+                if fate_prune_rule(cell):
                     _, _, self.pruned_lin_list = find_two_subtrees(
                         cell, self.pruned_lin_list)
                     cell.left = None

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -145,7 +145,7 @@ class LineageTree:
                 self.full_lin_list.append(left_cell)
                 self.full_lin_list.append(right_cell)
 
-            if len(self.full_lin_list) >= 2**10 - 1:
+            if len(self.full_lin_list) >= 2**11 - 1:
                 break
 
         return self.full_lin_list

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -50,6 +50,7 @@ class LineageTree:
         assert pi_num_states == T_num_states == E_num_states, "The number of states in your input Markov probability parameters are mistmatched. Please check that the dimensions and states match. "
         self.num_states = pi_num_states
         self.desired_experiment_time = desired_experiment_time
+        self.prune_condition = prune_condition # string for prune condition
         self.lineage_stats = []
 
         for state in range(self.num_states):
@@ -90,12 +91,12 @@ class LineageTree:
 
     @property
     def prune_boolean(self):
-        return self.prune_boolean
+        return self.__prune_boolean
 
     @prune_boolean.setter
     def prune_boolean(self, prune_boolean):
-        self.prune_boolean = prune_boolean
-        if self.prune_boolean == 'both':
+        self.__prune_boolean = prune_boolean
+        if self.prune_boolean:
             self.output_lineage = self.pruned_lin_list
             self.output_max_gen = self.pruned_max_gen
             self.output_list_of_gens = self.pruned_list_of_gens

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -23,7 +23,7 @@ class LineageStateStats:
 
 
 class LineageTree:
-    def __init__(self, pi, T, E, desired_num_cells, prune_boolean=True):
+    def __init__(self, pi, T, E, desired_num_cells, desired_experiment_time, prune_boolean=True):
         """
         A class for the structure of the lineage tree. Every lineage from this class is a binary tree built based on initial probabilities and transition probabilities given by the user that builds up the states based off of these until it reaches the desired number of cells in the tree, and then stops. Given the desired distributions for emission, the object will have the "E" a list of state distribution objects assigned to them.
 
@@ -50,6 +50,7 @@ class LineageTree:
         assert pi_num_states == T_num_states == E_num_states, "The number of states in your input Markov probability parameters are mistmatched. Please check that the dimensions and states match. "
         self.num_states = pi_num_states
         self.desired_num_cells = desired_num_cells
+        self.desired_experiment_time = desired_experiment_time
         self.lineage_stats = []
 
         for state in range(self.num_states):
@@ -153,7 +154,7 @@ class LineageTree:
         """
         self.pruned_lin_list = deepcopy(self.full_lin_list)
         for cell in self.pruned_lin_list:
-            if die_prune_rule(cell):
+            if die_prune_rule(cell, self.desired_experiment_time):
                 _, _, self.pruned_lin_list = find_two_subtrees(
                     cell, self.pruned_lin_list)
                 cell.left = None

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -23,7 +23,7 @@ class LineageStateStats:
 
 
 class LineageTree:
-    def __init__(self, pi, T, E, desired_experiment_time, prune_condition='both'):
+    def __init__(self, pi, T, E, desired_experiment_time, prune_condition='both', prune_boolean=True):
         """
         A class for the structure of the lineage tree. Every lineage from this class is a binary tree built based on initial probabilities and transition probabilities given by the user that builds up the states based off of these until it reaches the desired number of cells in the tree, and then stops. Given the desired distributions for emission, the object will have the "E" a list of state distribution objects assigned to them.
 
@@ -74,10 +74,14 @@ class LineageTree:
         self.pruned_leaves_idx, self.pruned_leaves = get_leaves(self.pruned_lin_list)
 
         # this is given by the user:
-        # 'die' - prune based on the fate of the cell
+        # 'fate' - prune based on the fate of the cell
         # 'time' - prune based on the length of the experiment
         # 'both' - prune based on both the 'die' and 'time' conditions
         self.prune_condition = prune_condition
+        
+        # this governs whether or not the pruned or the
+        # the unpruned lineage is used in the analysis
+        self.prune_boolean = prune_boolean
 
     # Based on the user's decision, if they want the lineage to be pruned (prune_boolean == True),
     # the lineage tree that is given to the tHMM, will be the pruned one.
@@ -85,12 +89,12 @@ class LineageTree:
     # then the full_lin_list will be passed to the output_lineage.
 
     @property
-    def prune_condition(self):
-        return self.prune_condition
+    def prune_boolean(self):
+        return self.prune_boolean
 
-    @prune_condition.setter
-    def prune_boolean(self, prune_condition):
-        self.prune_boolean = prune_condition
+    @prune_boolean.setter
+    def prune_boolean(self, prune_boolean):
+        self.prune_boolean = prune_boolean
         if self.prune_boolean == 'both':
             self.output_lineage = self.pruned_lin_list
             self.output_max_gen = self.pruned_max_gen
@@ -158,14 +162,14 @@ class LineageTree:
                     cell.left = None
                     cell.right = None
                     assert cell._isLeaf()
-            elseif self.prune_condition == 'die':
+            elif self.prune_condition == 'die':
                 if die_prune_rule(cell):
                     _, _, self.pruned_lin_list = find_two_subtrees(
                         cell, self.pruned_lin_list)
                     cell.left = None
                     cell.right = None
                     assert cell._isLeaf()          
-            elseif self.prune_condition == 'time':
+            elif self.prune_condition == 'time':
                 if time_prune_rule(cell, self.desired_experiment_time):
                     _, _, self.pruned_lin_list = find_two_subtrees(
                         cell, self.pruned_lin_list)
@@ -271,14 +275,17 @@ class LineageTree:
         return parent_holder
 
     def __repr__(self):
-        """ This function is used to get string representation of an object, used for debugging and development.
-        Represents the information about the lineage that the user has created, like whether the tree is pruned or is a full tree;
-        and for both of the options it prints the number of states, the number of cells in the states, the total number of cells.
+        """ 
+        This function is used to get string representation of an object, used for debugging and development.
+        Represents the information about the lineage that the user has created, 
+        like whether the tree is pruned or is a full tree;
+        and for both of the options it prints the number of states, 
+        the number of cells in the states, the total number of cells.
         """
         s1 = ""
         s2 = ""
         s3 = ""
-        if self._prune_boolean:
+        if self.prune_boolean:
             s1 = "This tree is pruned. It is made of {} states.\n For each state in this tree: ".format(
                 self.num_states)
             s_list = []
@@ -303,7 +310,10 @@ class LineageTree:
         return s1 + s2 + s3
 
     def __str__(self):
-        """ This function is used to get string representation of an object, used for showing the results to the user. """
+        """
+        This function is used to get string representation of an object,
+        used for showing the results to the user. 
+        """
         return self.__repr__()
 
 # tools for analyzing trees

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -3,6 +3,7 @@ import numpy as np
 import scipy.stats as sp
 import math
 
+
 class StateDistribution:
     def __init__(self, state, bern_p, gamma_a, gamma_loc, gamma_scale):  # user has to identify what parameters to use for each state
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
@@ -79,17 +80,20 @@ def tHMM_E_init(state):
                              0,
                              1)
 
+
 class Time:
     """
     Class that stores all the time related observations in a neater format.
     This will assist in pruning based on experimental time as well as
-    obtaining attributes of the lineage as a whole, such as the 
+    obtaining attributes of the lineage as a whole, such as the
     average growth rate.
     """
+
     def __init__(self, startT, lifetime, endT):
         self.startT = startT
         self.lifetime = lifetime
-        self.endT = endT # equivalent to endT
+        self.endT = endT  # equivalent to endT
+
 
 def assign_times(lineageObj):
     """
@@ -99,7 +103,7 @@ def assign_times(lineageObj):
     """
     # traversing the cells by generation
     for gen, level in enumerate(lineageObj.full_list_of_gens[1:]):
-        true_gen = gen+1 # generations are 1-indexed
+        true_gen = gen + 1  # generations are 1-indexed
         if true_gen == 1:
             for cell in level:
                 assert cell._isRootParent()
@@ -108,27 +112,29 @@ def assign_times(lineageObj):
             for cell in level:
                 cell.time = Time(cell.parent.time.endT,
                                  cell.obs[1],
-                                 cell.parent.time.endT+cell.obs[1])
+                                 cell.parent.time.endT + cell.obs[1])
+
 
 def get_experiment_time(lineageObj):
     """
-    This function returns the longest experiment time 
-    experienced by cells in the lineage. 
+    This function returns the longest experiment time
+    experienced by cells in the lineage.
     We can simply find the leaf cell with the
     longest end time. This is effectively
     the same as the experiment time for synthetic lineages.
     """
     longest = 0.0
     for cell in lineageObj.output_leaves:
-        if cell.time.endT>longest:
+        if cell.time.endT > longest:
             longest = cell.time.endT
     return longest
+
 
 def die_prune_rule(cell):
     """
     User-defined function that checks whether a cell's subtree should be removed.
-    Our example is based on the standard requirement that the first observation 
-    (index 0) is a measure of the cell's fate (1 being alive, 0 being dead). 
+    Our example is based on the standard requirement that the first observation
+    (index 0) is a measure of the cell's fate (1 being alive, 0 being dead).
     Clearly if a cell has died, its subtree must be removed.
     """
     truther = False
@@ -136,6 +142,7 @@ def die_prune_rule(cell):
         truther = True  # cell has died
         # subtree must be removed
     return truther
+
 
 def time_prune_rule(cell, desired_experiment_time):
     """
@@ -151,13 +158,14 @@ def time_prune_rule(cell, desired_experiment_time):
         # subtree must be removed
     return truther
 
-# Because parameter estimation requires that estimators be written or imported, 
+# Because parameter estimation requires that estimators be written or imported,
 # the user should be able to provide
-# estimators that can solve for the parameters that describe the distributions. 
+# estimators that can solve for the parameters that describe the distributions.
 # We provide some estimators below as an example.
-# Their use in the StateDistribution class is shown in the estimator class method. 
+# Their use in the StateDistribution class is shown in the estimator class method.
 # User must take care to define estimators that
 # can handle the case where the list of observations is empty.
+
 
 def bernoulli_estimator(bern_obs):
     """ Add up all the 1s and divide by the total length (finding the average). """

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -86,11 +86,10 @@ class Time:
     obtaining attributes of the lineage as a whole, such as the 
     average growth rate.
     """
-    def __init__(self, startT, endT, lifetime, timeThusFar):
+    def __init__(self, startT, lifetime, endT):
         self.startT = startT
-        self.endT = endT
         self.lifetime = lifetime
-        self.timeThusFar = timeThusFar
+        self.endT = endT # equivalent to endT
 
 def assign_times(lineageObj):
     """
@@ -99,29 +98,30 @@ def assign_times(lineageObj):
     in the second position (index 1). See the other time functions to understand.
     """
     # traversing the cells by generation
-    for gen, level in enumerate(lineageObj.output_list_of_gens[1:]):
+    for gen, level in enumerate(lineageObj.full_list_of_gens[1:]):
         true_gen = gen+1 # generations are 1-indexed
         if true_gen == 1:
             for cell in level:
                 assert cell._isRootParent()
-                cell.time = Time(0, cell.obs[1], cell.obs[1], cell.obs[1])
+                cell.time = Time(0, cell.obs[1], cell.obs[1])
         else:
             for cell in level:
                 cell.time = Time(cell.parent.time.endT,
-                                 cell.parent.time.endT+cell.obs[1],
                                  cell.obs[1],
-                                 cell.parent.time.timeThusFar+cell.obs[1])
+                                 cell.parent.time.endT+cell.obs[1])
 
 def get_experiment_time(lineageObj):
     """
     This function returns the longest experiment time 
-    experienced by cells in the lineage. This is effectively
+    experienced by cells in the lineage. 
+    We can simply find the leaf cell with the
+    longest end time. This is effectively
     the same as the experiment time for synthetic lineages.
     """
-    leaf_timesThusFar = []
+    longest = 0.0
     for cell in lineageObj.output_leaves:
-        leaf_timesThusFar.append(cell.time.timeThusFar)
-    longest = max(leaf_timesThusFar)
+        if cell.time.endT>longest:
+            longest = cell.time.endT
     return longest
 
 def die_prune_rule(cell):
@@ -146,8 +146,8 @@ def time_prune_rule(cell, desired_experiment_time):
     must be removed.
     """
     truther = False
-    if cell.time.timeThusFar > desired_experiment_time:
-        truther = True  # cell has died
+    if cell.time.endT > desired_experiment_time:
+        truther = True  # cell died after the experiment ended
         # subtree must be removed
     return truther
 

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -109,7 +109,8 @@ def assign_times(lineageObj):
     """
     # traversing the cells by generation
     for gen, level in enumerate(lineageObj.output_list_of_gens[1:]):
-        if gen == 1:
+        true_gen = gen+1 # generations are 1-indexed
+        if true_gen == 1:
             for cell in level:
                 assert cell._isRootParent()
                 cell.time = Time(0, cell.obs[1], cell.obs[1], cell.obs[1])

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -72,11 +72,12 @@ class StateDistribution:
         return "State object w/ parameters: {}, {}, {}, {}.".format(self.bern_p, self.gamma_a, self.gamma_loc, self.gamma_scale)
 
 
-def die_prune_rule(cell):
+def die_prune_rule(cell, desired_experiment_time):
     """ User-defined function that checks whether a cell's subtree should be removed. """
     truther = False
-    if cell.obs[0] == 0:
-        truther = True  # cell has died; subtree must be removed
+    if cell.obs[0] == 0 or cell.time.timeThusFar > desired_experiment_time:
+        truther = True  # cell has died or lived past the experiment time
+        # subtree must be removed
     return truther
 
 

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -87,7 +87,28 @@ def tHMM_E_init(state):
                              0,
                              1)
 
+
+class Time:
+    def __init__(self, startT, endT, lifetime):
+        self.startT = startT
+        self.endT = endT
+        self.lifetime = lifetime
+
 def assign_times(lineageObj):
+    """
+    Assigns the start and end time for each cell in the lineage.
+    The time observation will be stored in the cell's observation parameter list
+    in the first position. See the other time functions to understand.
+    """
+    # traversing the cells by generation
+    for gen, level in enumerate(lineageObj.output_list_of_gens[1:]):
+        if gen == 1:
+            for cell in level:
+                assert cell._isRootParent()
+                cell.time = Time(0, cell.obs[1], cell.obs[1])
+        else:
+            for cell in level:
+                cell.time = Time(cell.parent.time.endT, cell.parent.time.endT+cell.obs[1], cell.obs[1])
     
 
 def report_time(cell):

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -124,7 +124,7 @@ def get_experiment_time(lineageObj):
     longest = max(leaf_timesThusFar)
     return longest
 
-def die_prune_rule(cell, desired_experiment_time):
+def die_prune_rule(cell):
     """
     User-defined function that checks whether a cell's subtree should be removed.
     Our example is based on the standard requirement that the first observation 
@@ -137,7 +137,7 @@ def die_prune_rule(cell, desired_experiment_time):
         # subtree must be removed
     return truther
 
-def time_prune_rule(desired_experiment_time):
+def time_prune_rule(cell, desired_experiment_time):
     """
     User-defined function that checks whether a cell's subtree should be removed.
     Our example is based on the standard requirement that the second observation
@@ -145,6 +145,11 @@ def time_prune_rule(desired_experiment_time):
     If a cell has lived beyond a certain experiment time, then its subtree
     must be removed.
     """
+    truther = False
+    if cell.time.timeThusFar > desired_experiment_time:
+        truther = True  # cell has died
+        # subtree must be removed
+    return truther
 
 # Because parameter estimation requires that estimators be written or imported, 
 # the user should be able to provide

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -72,29 +72,12 @@ class StateDistribution:
         return "State object w/ parameters: {}, {}, {}, {}.".format(self.bern_p, self.gamma_a, self.gamma_loc, self.gamma_scale)
 
 
-def die_prune_rule(cell, desired_experiment_time):
-    """
-    User-defined function that checks whether a cell's subtree should be removed.
-    Our example is based on the standard requirement that the first observation 
-    is a measure of the cell's fate (1 being alive, 0 being dead) and the second
-    observation being the cell's lifetime. Clearly if a cell has died, its subtree
-    must be removed. If a cell's end time exceeds past a certain experimental time then 
-    its subtree must be removed.
-    """
-    truther = False
-    if cell.obs[0] == 0 or cell.time.timeThusFar > desired_experiment_time:
-        truther = True  # cell has died or lived past the experiment time
-        # subtree must be removed
-    return truther
-
-
 def tHMM_E_init(state):
     return StateDistribution(state,
                              0.9,
                              10 * (np.random.uniform()),
                              0,
                              1)
-
 
 class Time:
     """
@@ -140,6 +123,28 @@ def get_experiment_time(lineageObj):
         leaf_timesThusFar.append(cell.time.timeThusFar)
     longest = max(leaf_timesThusFar)
     return longest
+
+def die_prune_rule(cell, desired_experiment_time):
+    """
+    User-defined function that checks whether a cell's subtree should be removed.
+    Our example is based on the standard requirement that the first observation 
+    (index 0) is a measure of the cell's fate (1 being alive, 0 being dead). 
+    Clearly if a cell has died, its subtree must be removed.
+    """
+    truther = False
+    if cell.obs[0] == 0:
+        truther = True  # cell has died
+        # subtree must be removed
+    return truther
+
+def time_prune_rule(desired_experiment_time):
+    """
+    User-defined function that checks whether a cell's subtree should be removed.
+    Our example is based on the standard requirement that the second observation
+    (index 1) is a measure of the cell's lifetime.
+    If a cell has lived beyond a certain experiment time, then its subtree
+    must be removed.
+    """
 
 # Because parameter estimation requires that estimators be written or imported, 
 # the user should be able to provide

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -3,7 +3,6 @@ import numpy as np
 import scipy.stats as sp
 import math
 
-
 class StateDistribution:
     def __init__(self, state, bern_p, gamma_a, gamma_loc, gamma_scale):  # user has to identify what parameters to use for each state
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
@@ -88,11 +87,8 @@ def tHMM_E_init(state):
                              0,
                              1)
 
-# Because parameter estimation requires that estimators be written or imported, the user should be able to provide
-# estimators that can solve for the parameters that describe the distributions. We provide some estimators below as an example.
-# Their use in the StateDistribution class is shown in the estimator class method. User must take care to define estimators that
-# can handle the case where the list of observations is empty.
-
+def assign_times(lineageObj):
+    
 
 def report_time(cell):
     """ Given any cell in the lineage, this function walks through the cell's ancestors and return how long it has taken so far. """
@@ -108,15 +104,19 @@ def report_time(cell):
     return taus
 
 
-def get_experiment_time(lineage):
+def get_experiment_time(lineageObj):
     """ This function is to find the amount of time it took for the cells to be generated and reach to the desired number of cells. """
     leaf_times = []
-    for cell in lineage.output_leaves:
+    for cell in lineageObj.output_leaves:
         temp = report_time(cell)
         leaf_times.append(temp)
     longest = max(leaf_times)
     return longest
 
+# Because parameter estimation requires that estimators be written or imported, the user should be able to provide
+# estimators that can solve for the parameters that describe the distributions. We provide some estimators below as an example.
+# Their use in the StateDistribution class is shown in the estimator class method. User must take care to define estimators that
+# can handle the case where the list of observations is empty.
 
 def bernoulli_estimator(bern_obs):
     """ Add up all the 1s and divide by the total length (finding the average). """

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -73,7 +73,7 @@ class StateDistribution:
         return "State object w/ parameters: {}, {}, {}, {}.".format(self.bern_p, self.gamma_a, self.gamma_loc, self.gamma_scale)
 
 
-def prune_rule(cell):
+def die_prune_rule(cell):
     """ User-defined function that checks whether a cell's subtree should be removed. """
     truther = False
     if cell.obs[0] == 0:

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -130,7 +130,7 @@ def get_experiment_time(lineageObj):
     return longest
 
 
-def die_prune_rule(cell):
+def fate_prune_rule(cell):
     """
     User-defined function that checks whether a cell's subtree should be removed.
     Our example is based on the standard requirement that the first observation

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -89,54 +89,55 @@ def tHMM_E_init(state):
 
 
 class Time:
-    def __init__(self, startT, endT, lifetime):
+    """
+    Class that stores all the time related observations in a neater format.
+    This will assist in pruning based on experimental time as well as
+    obtaining attributes of the lineage as a whole, such as the 
+    average growth rate.
+    """
+    def __init__(self, startT, endT, lifetime, timeThusFar):
         self.startT = startT
         self.endT = endT
         self.lifetime = lifetime
+        self.timeThusFar = timeThusFar
 
 def assign_times(lineageObj):
     """
     Assigns the start and end time for each cell in the lineage.
     The time observation will be stored in the cell's observation parameter list
-    in the first position. See the other time functions to understand.
+    in the second position (index 1). See the other time functions to understand.
     """
     # traversing the cells by generation
     for gen, level in enumerate(lineageObj.output_list_of_gens[1:]):
         if gen == 1:
             for cell in level:
                 assert cell._isRootParent()
-                cell.time = Time(0, cell.obs[1], cell.obs[1])
+                cell.time = Time(0, cell.obs[1], cell.obs[1], cell.obs[1])
         else:
             for cell in level:
-                cell.time = Time(cell.parent.time.endT, cell.parent.time.endT+cell.obs[1], cell.obs[1])
-    
-
-def report_time(cell):
-    """ Given any cell in the lineage, this function walks through the cell's ancestors and return how long it has taken so far. """
-    list_parents = [cell]
-    taus = 0.0 + cell.obs[1]
-
-    for cell in list_parents:
-        if cell._isRootParent():
-            break
-        elif cell.parent not in list_parents:
-            list_parents.append(cell.parent)
-            taus += cell.parent.obs[1]
-    return taus
-
+                cell.time = Time(cell.parent.time.endT,
+                                 cell.parent.time.endT+cell.obs[1],
+                                 cell.obs[1],
+                                 cell.parent.time.timeThusFar+cell.obs[1])
 
 def get_experiment_time(lineageObj):
-    """ This function is to find the amount of time it took for the cells to be generated and reach to the desired number of cells. """
-    leaf_times = []
+    """
+    This function returns the longest experiment time 
+    experienced by cells in the lineage. This is effectively
+    the same as the experiment time for synthetic lineages.
+    """
+    leaf_timesThusFar = []
     for cell in lineageObj.output_leaves:
-        temp = report_time(cell)
-        leaf_times.append(temp)
-    longest = max(leaf_times)
+        leaf_timesThusFar.append(cell.time.timeThusFar)
+    longest = max(leaf_timesThusFar)
     return longest
 
-# Because parameter estimation requires that estimators be written or imported, the user should be able to provide
-# estimators that can solve for the parameters that describe the distributions. We provide some estimators below as an example.
-# Their use in the StateDistribution class is shown in the estimator class method. User must take care to define estimators that
+# Because parameter estimation requires that estimators be written or imported, 
+# the user should be able to provide
+# estimators that can solve for the parameters that describe the distributions. 
+# We provide some estimators below as an example.
+# Their use in the StateDistribution class is shown in the estimator class method. 
+# User must take care to define estimators that
 # can handle the case where the list of observations is empty.
 
 def bernoulli_estimator(bern_obs):

--- a/lineage/StateDistribution.py
+++ b/lineage/StateDistribution.py
@@ -73,7 +73,14 @@ class StateDistribution:
 
 
 def die_prune_rule(cell, desired_experiment_time):
-    """ User-defined function that checks whether a cell's subtree should be removed. """
+    """
+    User-defined function that checks whether a cell's subtree should be removed.
+    Our example is based on the standard requirement that the first observation 
+    is a measure of the cell's fate (1 being alive, 0 being dead) and the second
+    observation being the cell's lifetime. Clearly if a cell has died, its subtree
+    must be removed. If a cell's end time exceeds past a certain experimental time then 
+    its subtree must be removed.
+    """
     truther = False
     if cell.obs[0] == 0 or cell.time.timeThusFar > desired_experiment_time:
         truther = True  # cell has died or lived past the experiment time

--- a/lineage/figures/figure6.py
+++ b/lineage/figures/figure6.py
@@ -41,11 +41,16 @@ def makeFigure():
     return f
 
 
-
 # Main figure generating function for Fig. 6 if we have G1 and G2 phase
 # x_unpruned, accuracies_unpruned, bern_unpruned, bern_p0, bern_p1, gamma_aG1_unpruned, gamma_aG2_unpruned, gamma_aG11, gamma_aG12, gamma_aG21, gamma_aG22, gamma_scaleG1_unpruned, gamma_scaleG2_unpruned, gamma_scaleG11, gamma_scaleG12, gamma_scaleG21, gamma_scaleG22, x_pruned, accuracies_pruned, bern_pruned, gamma_aG1_pruned, gamma_scaleG1_pruned, gamma_aG2_pruned, gamma_scaleG2_pruned, tr_unprunedNorm, tr_prunedNorm, pi_unprunedNorm, pi_prunedNorm = accuracy_increased_cellsG()
 # figure_makerG(
-#     ax, x_unpruned, accuracies_unpruned, bern_unpruned, bern_p0, bern_p1, gamma_aG1_unpruned, gamma_aG2_unpruned, gamma_aG11, gamma_aG12, gamma_aG21, gamma_aG22, gamma_scaleG1_unpruned, gamma_scaleG2_unpruned, gamma_scaleG11, gamma_scaleG12, gamma_scaleG21, gamma_scaleG22, x_pruned, accuracies_pruned, bern_pruned, gamma_aG1_pruned, gamma_scaleG1_pruned, gamma_aG2_pruned, gamma_scaleG2_pruned, tr_unprunedNorm, tr_prunedNorm, pi_unprunedNorm, pi_prunedNorm)
+# ax, x_unpruned, accuracies_unpruned, bern_unpruned, bern_p0, bern_p1,
+# gamma_aG1_unpruned, gamma_aG2_unpruned, gamma_aG11, gamma_aG12,
+# gamma_aG21, gamma_aG22, gamma_scaleG1_unpruned, gamma_scaleG2_unpruned,
+# gamma_scaleG11, gamma_scaleG12, gamma_scaleG21, gamma_scaleG22,
+# x_pruned, accuracies_pruned, bern_pruned, gamma_aG1_pruned,
+# gamma_scaleG1_pruned, gamma_aG2_pruned, gamma_scaleG2_pruned,
+# tr_unprunedNorm, tr_prunedNorm, pi_unprunedNorm, pi_prunedNorm)
 
 
 # -------------------- Figure 6

--- a/lineage/tHMM.py
+++ b/lineage/tHMM.py
@@ -42,7 +42,6 @@ class tHMM:
 
 ##---------------------------- Marginal State Distribution ------------------------------##
 
-
     def get_Marginal_State_Distributions(self):
         '''
         Marginal State Distribution (MSD) matrix and recursion.
@@ -95,6 +94,7 @@ class tHMM:
 
 
 ##--------------------------- Emission Likelihood --------------------------------##
+
 
     def get_Emission_Likelihoods(self):
         '''

--- a/lineage/tHMM.py
+++ b/lineage/tHMM.py
@@ -42,6 +42,7 @@ class tHMM:
 
 ##---------------------------- Marginal State Distribution ------------------------------##
 
+
     def get_Marginal_State_Distributions(self):
         '''
         Marginal State Distribution (MSD) matrix and recursion.
@@ -94,7 +95,6 @@ class tHMM:
 
 
 ##--------------------------- Emission Likelihood --------------------------------##
-
 
     def get_Emission_Likelihoods(self):
         '''

--- a/lineage/tests/test_BaumWelch.py
+++ b/lineage/tests/test_BaumWelch.py
@@ -37,9 +37,9 @@ class TestBW(unittest.TestCase):
         state_obj1 = StateDistribution(state1, bern_p1, gamma_a1, gamma_loc, gamma_scale1)
 
         E = [state_obj0, state_obj1]
-        num = 2**7 - 1
+
         # Using an unpruned lineage to avoid unforseen issues
-        X = LineageTree(pi, T, E, 500, prune_condition='die', prune_boolean=False)
+        X = LineageTree(pi, T, E, desired_experiment_time=500, prune_condition='die', prune_boolean=False)
         tHMMobj = tHMM([X], numStates=2)  # build the tHMM class with X
 
         # Test cases below

--- a/lineage/tests/test_BaumWelch.py
+++ b/lineage/tests/test_BaumWelch.py
@@ -39,7 +39,7 @@ class TestBW(unittest.TestCase):
         E = [state_obj0, state_obj1]
         num = 2**7 - 1
         # Using an unpruned lineage to avoid unforseen issues
-        X = LineageTree(pi, T, E, num, prune_boolean=False)
+        X = LineageTree(pi, T, E, 500, prune_condition='die', prune_boolean=False)
         tHMMobj = tHMM([X], numStates=2)  # build the tHMM class with X
 
         # Test cases below

--- a/lineage/tests/test_LineageTree.py
+++ b/lineage/tests/test_LineageTree.py
@@ -40,14 +40,14 @@ class TestModel(unittest.TestCase):
             self.T,
             self.E,
             desired_experiment_time=500,
-            prune_condition='die',
+            prune_condition='fate',
             prune_boolean=False)
-        self.lineage2_pruned_die = LineageTree(
+        self.lineage2_pruned_fate = LineageTree(
             self.pi,
             self.T,
             self.E,
             desired_experiment_time=500,
-            prune_condition='die',
+            prune_condition='fate',
             prune_boolean=True)
         self.lineage3_pruned_time = LineageTree(
             self.pi,
@@ -141,8 +141,8 @@ class TestModel(unittest.TestCase):
         self.assertTrue(len(self.lineage1.full_lin_list) == 2**11 - 1)
         self.assertTrue(self.lineage1.full_lin_list ==
                         self.lineage1.output_lineage)
-        self.assertTrue(self.lineage2_pruned_die.pruned_lin_list ==
-                        self.lineage2_pruned_die.output_lineage)
+        self.assertTrue(self.lineage2_pruned_fate.pruned_lin_list ==
+                        self.lineage2_pruned_fate.output_lineage)
 
     def test_prune_lineage(self):
         """ A unittest for prune_lineage. """
@@ -158,7 +158,7 @@ class TestModel(unittest.TestCase):
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)
-        for cell in self.lineage2_pruned_die.pruned_lin_list:
+        for cell in self.lineage2_pruned_fate.pruned_lin_list:
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)

--- a/lineage/tests/test_LineageTree.py
+++ b/lineage/tests/test_LineageTree.py
@@ -153,21 +153,19 @@ class TestModel(unittest.TestCase):
 
         # checking all the cells in the pruned version should have all the
         # bernoulli observations == 1 (dead cells have been removed.)
+        self.assertGreater(get_experiment_time(self.lineage1), 500)
         for cell in self.lineage1.pruned_lin_list:
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)
-                self.assertGreater(get_experiment_time(lineage1), 500)
         for cell in self.lineage2_pruned_die.pruned_lin_list:
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)
-                self.assertGreater(get_experiment_time(lineage1), 500)
         for cell in self.lineage3_pruned_time.pruned_lin_list:
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)
-
         for cell in self.lineage4_pruned_both.pruned_lin_list:
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)

--- a/lineage/tests/test_LineageTree.py
+++ b/lineage/tests/test_LineageTree.py
@@ -34,7 +34,7 @@ class TestModel(unittest.TestCase):
 
         self.E = [state_obj0, state_obj1]
 
-        # creating two lineages, one with False for pruning, one with True.
+        # creating lineages with the various prune conditions
         self.lineage1 = LineageTree(
             self.pi,
             self.T,
@@ -42,7 +42,7 @@ class TestModel(unittest.TestCase):
             desired_experiment_time=500,
             prune_condition='die',
             prune_boolean=False)
-        self.lineage2_pruned = LineageTree(
+        self.lineage2_pruned_die = LineageTree(
             self.pi,
             self.T,
             self.E,
@@ -125,11 +125,11 @@ class TestModel(unittest.TestCase):
         """ A unittest for generate_lineage_list. """
         # checking the number of cells generated is equal to the desired
         # number of cells given by the user.
-        self.assertTrue(len(self.lineage1.full_lin_list) == 2**10 - 1)
+        self.assertTrue(len(self.lineage1.full_lin_list) == 2**11 - 1)
         self.assertTrue(self.lineage1.full_lin_list ==
                         self.lineage1.output_lineage)
-        self.assertTrue(self.lineage2_pruned.pruned_lin_list ==
-                        self.lineage2_pruned.output_lineage)
+        self.assertTrue(self.lineage2_pruned_die.pruned_lin_list ==
+                        self.lineage2_pruned_die.output_lineage)
 
     def test_prune_lineage(self):
         """ A unittest for prune_lineage. """
@@ -145,7 +145,7 @@ class TestModel(unittest.TestCase):
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)
 
-        for cell in self.lineage2_pruned.pruned_lin_list:
+        for cell in self.lineage2_pruned_die.pruned_lin_list:
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)
@@ -155,14 +155,14 @@ class TestModel(unittest.TestCase):
         num_cells_in_state, cells_in_state, indices_of_cells_in_state = self.lineage1._get_full_state_count(
             self.state0)
         self.assertTrue(len(cells_in_state) == num_cells_in_state)
-        self.assertTrue(num_cells_in_state <= 2**10 - 1)
-        self.assertTrue(max(indices_of_cells_in_state) <= 2**10 - 1)
+        self.assertTrue(num_cells_in_state <= 2**11 - 1)
+        self.assertTrue(max(indices_of_cells_in_state) <= 2**11 - 1)
 
         num_cells_in_state1, cells_in_state1, indices_of_cells_in_state1 = self.lineage1._get_full_state_count(
             self.state1)
         self.assertTrue(len(cells_in_state1) == num_cells_in_state1)
-        self.assertTrue(num_cells_in_state1 <= 2**10 - 1)
-        self.assertTrue(max(indices_of_cells_in_state1) <= 2**10 - 1)
+        self.assertTrue(num_cells_in_state1 <= 2**11 - 1)
+        self.assertTrue(max(indices_of_cells_in_state1) <= 2**11 - 1)
 
     def test_get_pruned_state_count(self):
         """ A unittest for _get_pruned_state_count. """
@@ -174,7 +174,7 @@ class TestModel(unittest.TestCase):
                         )
         if len(indices_of_cells_in_state) > 0:
             self.assertTrue(
-                max(indices_of_cells_in_state) <= (2**10 - 1))
+                max(indices_of_cells_in_state) <= (2**11 - 1))
 
         num_cells_in_state1, cells_in_state1, list_of_tuples_of_obs1, indices_of_cells_in_state1 = self.lineage1._get_pruned_state_count(
             self.state1)
@@ -183,7 +183,7 @@ class TestModel(unittest.TestCase):
         self.assertTrue(num_cells_in_state1 <= len(self.lineage1.pruned_lin_list)
                         )
         if len(indices_of_cells_in_state) > 0:
-            self.assertTrue(max(indices_of_cells_in_state1) <= (2**10 - 1))
+            self.assertTrue(max(indices_of_cells_in_state1) <= (2**11 - 1))
 
     def test_full_assign_obs(self):
         """ A unittest for checking the full_assign_obs function. """

--- a/lineage/tests/test_LineageTree.py
+++ b/lineage/tests/test_LineageTree.py
@@ -125,7 +125,7 @@ class TestModel(unittest.TestCase):
         """ A unittest for generate_lineage_list. """
         # checking the number of cells generated is equal to the desired
         # number of cells given by the user.
-        self.assertTrue(len(self.lineage1.full_lin_list) == 2**9 - 1)
+        self.assertTrue(len(self.lineage1.full_lin_list) == 2**10 - 1)
         self.assertTrue(self.lineage1.full_lin_list ==
                         self.lineage1.output_lineage)
         self.assertTrue(self.lineage2_pruned.pruned_lin_list ==
@@ -155,18 +155,14 @@ class TestModel(unittest.TestCase):
         num_cells_in_state, cells_in_state, indices_of_cells_in_state = self.lineage1._get_full_state_count(
             self.state0)
         self.assertTrue(len(cells_in_state) == num_cells_in_state)
-        self.assertTrue(num_cells_in_state <= 2**9 -
-                        1)
-        self.assertTrue(max(indices_of_cells_in_state) <= 2**9 -
-                        1)
+        self.assertTrue(num_cells_in_state <= 2**10 - 1)
+        self.assertTrue(max(indices_of_cells_in_state) <= 2**10 - 1)
 
         num_cells_in_state1, cells_in_state1, indices_of_cells_in_state1 = self.lineage1._get_full_state_count(
             self.state1)
         self.assertTrue(len(cells_in_state1) == num_cells_in_state1)
-        self.assertTrue(num_cells_in_state1 <= 2**9 -
-                        1)
-        self.assertTrue(max(indices_of_cells_in_state1) <= 2**9 -
-                        1)
+        self.assertTrue(num_cells_in_state1 <= 2**10 - 1)
+        self.assertTrue(max(indices_of_cells_in_state1) <= 2**10 - 1)
 
     def test_get_pruned_state_count(self):
         """ A unittest for _get_pruned_state_count. """
@@ -178,8 +174,7 @@ class TestModel(unittest.TestCase):
                         )
         if len(indices_of_cells_in_state) > 0:
             self.assertTrue(
-                max(indices_of_cells_in_state) <= (
-                    2**9 - 1))
+                max(indices_of_cells_in_state) <= (2**10 - 1))
 
         num_cells_in_state1, cells_in_state1, list_of_tuples_of_obs1, indices_of_cells_in_state1 = self.lineage1._get_pruned_state_count(
             self.state1)
@@ -188,8 +183,7 @@ class TestModel(unittest.TestCase):
         self.assertTrue(num_cells_in_state1 <= len(self.lineage1.pruned_lin_list)
                         )
         if len(indices_of_cells_in_state) > 0:
-            self.assertTrue(max(indices_of_cells_in_state1) <= (
-                2**9 - 1))
+            self.assertTrue(max(indices_of_cells_in_state1) <= (2**10 - 1))
 
     def test_full_assign_obs(self):
         """ A unittest for checking the full_assign_obs function. """

--- a/lineage/tests/test_LineageTree.py
+++ b/lineage/tests/test_LineageTree.py
@@ -55,14 +55,14 @@ class TestModel(unittest.TestCase):
             self.E,
             desired_experiment_time=500,
             prune_condition='time',
-            prune_boolean=True)    
+            prune_boolean=True)
         self.lineage4_pruned_both = LineageTree(
             self.pi,
             self.T,
             self.E,
             desired_experiment_time=500,
             prune_condition='both',
-            prune_boolean=True) 
+            prune_boolean=True)
         # creating 7 cells for 3 generations manually
         cell_1 = c(
             state=self.state0,

--- a/lineage/tests/test_LineageTree.py
+++ b/lineage/tests/test_LineageTree.py
@@ -39,13 +39,15 @@ class TestModel(unittest.TestCase):
             self.pi,
             self.T,
             self.E,
-            desired_num_cells=2**9 - 1,
+            desired_experiment_time=500,
+            prune_condition='die',
             prune_boolean=False)
         self.lineage2_pruned = LineageTree(
             self.pi,
             self.T,
             self.E,
-            desired_num_cells=2**9 - 1,
+            desired_experiment_time=500,
+            prune_condition='die',
             prune_boolean=True)
 
         # creating 7 cells for 3 generations manually

--- a/lineage/tests/test_LineageTree.py
+++ b/lineage/tests/test_LineageTree.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from ..CellVar import CellVar as c
 from ..LineageTree import LineageTree, max_gen, get_leaves, get_subtrees, find_two_subtrees, get_mixed_subtrees
-from ..StateDistribution import StateDistribution
+from ..StateDistribution import StateDistribution, get_experiment_time
 
 
 class TestModel(unittest.TestCase):
@@ -49,7 +49,20 @@ class TestModel(unittest.TestCase):
             desired_experiment_time=500,
             prune_condition='die',
             prune_boolean=True)
-
+        self.lineage3_pruned_time = LineageTree(
+            self.pi,
+            self.T,
+            self.E,
+            desired_experiment_time=500,
+            prune_condition='time',
+            prune_boolean=True)    
+        self.lineage4_pruned_both = LineageTree(
+            self.pi,
+            self.T,
+            self.E,
+            desired_experiment_time=500,
+            prune_condition='both',
+            prune_boolean=True) 
         # creating 7 cells for 3 generations manually
         cell_1 = c(
             state=self.state0,
@@ -144,8 +157,18 @@ class TestModel(unittest.TestCase):
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)
-
+                self.assertGreater(get_experiment_time(lineage1), 500)
         for cell in self.lineage2_pruned_die.pruned_lin_list:
+            if cell._isLeaf():
+                self.assertTrue(cell.left is None)
+                self.assertTrue(cell.right is None)
+                self.assertGreater(get_experiment_time(lineage1), 500)
+        for cell in self.lineage3_pruned_time.pruned_lin_list:
+            if cell._isLeaf():
+                self.assertTrue(cell.left is None)
+                self.assertTrue(cell.right is None)
+
+        for cell in self.lineage4_pruned_both.pruned_lin_list:
             if cell._isLeaf():
                 self.assertTrue(cell.left is None)
                 self.assertTrue(cell.right is None)

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 import scipy.stats as sp
-from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, die_prune_rule, time_prune_rule, get_experiment_time
+from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, fate_prune_rule, time_prune_rule, get_experiment_time
 from ..LineageTree import LineageTree
 
 
@@ -39,7 +39,7 @@ class TestModel(unittest.TestCase):
             self.T,
             self.E,
             desired_experiment_time=500,
-            prune_condition='die',
+            prune_condition='fate',
             prune_boolean=False)
         self.lineage2 = LineageTree(
             self.pi,
@@ -104,16 +104,16 @@ class TestModel(unittest.TestCase):
                 estimator_obj.gamma_scale -
                 self.stateDist0.gamma_scale) <= 3.0)
 
-    def test_die_prune_rule(self):
-        """ A unittest for the die_prune_rule. """
+    def test_fate_prune_rule(self):
+        """ A unittest for the fate_prune_rule. """
 
         for cell in self.lineage.lineage_stats[0].full_lin_cells:
             if cell.obs[0] == 0:
-                self.assertTrue(die_prune_rule(cell))
+                self.assertTrue(fate_prune_rule(cell))
 
         for cell in self.lineage.lineage_stats[1].full_lin_cells:
             if cell.obs[0] == 0:
-                self.assertTrue(die_prune_rule(cell))
+                self.assertTrue(fate_prune_rule(cell))
 
     def test_time_prune_rule(self):
         """ A unittest for the time_prune_rule. """

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 import scipy.stats as sp
-from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, die_prune_rule, get_experiment_time
+from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, die_prune_rule, time_prune_rule, get_experiment_time
 from ..LineageTree import LineageTree
 
 
@@ -38,13 +38,15 @@ class TestModel(unittest.TestCase):
             self.pi,
             self.T,
             self.E,
-            desired_num_cells=2**3 - 1,
-            prune_boolean=False)  # 7-cell lineage
+            desired_experiment_time=500,
+            prune_condition='die',
+            prune_boolean=False)
         self.lineage2 = LineageTree(
             self.pi,
             self.T,
             self.E,
-            desired_num_cells=2**2 - 1,
+            desired_experiment_time=500,
+            prune_condition='die',
             prune_boolean=False)
 
     def test_rvs(self):
@@ -95,39 +97,16 @@ class TestModel(unittest.TestCase):
                 estimator_obj.gamma_scale -
                 self.stateDist0.gamma_scale) <= 3.0)
 
-    def test_prune_rule(self):
-        """ A unittest for the prune_rule. """
+    def test_die_prune_rule(self):
+        """ A unittest for the die_prune_rule. """
 
         for cell in self.lineage.lineage_stats[0].full_lin_cells:
             if cell.obs[0] == 0:
-                self.assertTrue(prune_rule(cell))
+                self.assertTrue(die_prune_rule(cell))
 
         for cell in self.lineage.lineage_stats[1].full_lin_cells:
             if cell.obs[0] == 0:
-                self.assertTrue(prune_rule(cell))
-
-    def test_get_experiment_time(self):
-        """
-        A unittest to check the experiment time is
-        reported correctly. Here we use a lineage with 3 cells,
-        self.lineage2 built in the setup function.
-        """
-        full_lin_cells_holder = []
-        for state in range(2):
-            full_lin_cells_holder.append(
-                self.lineage2.lineage_stats[state].full_lin_cells)
-
-        # bringing all the cells after assigning observations to them
-        all_cells = [cell for sublist in full_lin_cells_holder for cell in sublist]
-
-        # here we check this for the root parent, since the time has taken
-        # so far, equals to the lifetime of the cell
-        for cell in all_cells:
-            if cell._isRootParent():
-                left = cell.obs[1] + cell.left.obs[1]
-                right = cell.obs[1] + cell.right.obs[1]
-        maximum = max(left, right)
-        self.assertTrue(get_experiment_time(self.lineage2) == maximum)
+                self.assertTrue(die_prune_rule(cell))
 
     def test_bernoulli_estimator(self):
         """

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -114,25 +114,25 @@ class TestModel(unittest.TestCase):
         for cell in self.lineage.lineage_stats[1].full_lin_cells:
             if cell.obs[0] == 0:
                 self.assertTrue(die_prune_rule(cell))
-                
+
     def test_time_prune_rule(self):
         """ A unittest for the time_prune_rule. """
 
         for cell in self.lineage3.lineage_stats[0].full_lin_cells:
             if cell.time.endT > self.lineage3.desired_experiment_time:
-                self.assertTrue(time_prune_rule(cell,self.lineage3.desired_experiment_time))
+                self.assertTrue(time_prune_rule(cell, self.lineage3.desired_experiment_time))
 
         for cell in self.lineage3.lineage_stats[1].full_lin_cells:
             if cell.time.endT > self.lineage3.desired_experiment_time:
-                self.assertTrue(time_prune_rule(cell,self.lineage3.desired_experiment_time))
-                
+                self.assertTrue(time_prune_rule(cell, self.lineage3.desired_experiment_time))
+
     def test_get_experiment_time(self):
         """
         A unittest for obtaining the experiment time.
         """
         experiment_time2 = get_experiment_time(self.lineage2)
         experiment_time3 = get_experiment_time(self.lineage3)
-        self.assertLess(experiment_time2,experiment_time3)
+        self.assertLess(experiment_time2, experiment_time3)
 
     def test_bernoulli_estimator(self):
         """

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 import scipy.stats as sp
-from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, die_prune_rule, report_time, get_experiment_time
+from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, die_prune_rule, get_experiment_time
 from ..LineageTree import LineageTree
 
 
@@ -105,32 +105,6 @@ class TestModel(unittest.TestCase):
         for cell in self.lineage.lineage_stats[1].full_lin_cells:
             if cell.obs[0] == 0:
                 self.assertTrue(prune_rule(cell))
-
-    def test_report_time(self):
-        """
-        Given a cell, the report_time function has to
-        return the time since the start of the experiment
-        to the time of this cell's time.
-        """
-        full_lin_cells_holder = []
-        for state in range(2):
-            full_lin_cells_holder.append(self.lineage.lineage_stats[state].full_lin_cells)
-
-        # bringing all the cells after assigning observations to them
-        all_cells = [cell for sub_statelist in full_lin_cells_holder for cell in sub_statelist]
-
-        # here we check this for the root parent, since the time has taken
-        # so far, equals to the lifetime of the cell
-        for cell in all_cells:
-            if cell._isRootParent():
-                parent_tau = cell.obs[1]
-                self.assertTrue(report_time(cell) == parent_tau)
-
-        # here we check for the root parent and its left child
-        for cell in all_cells:
-            if cell._isRootParent():
-                taus = cell.obs[1] + cell.left.obs[1]
-                self.assertTrue(report_time(cell.left) == taus)
 
     def test_get_experiment_time(self):
         """

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -45,9 +45,16 @@ class TestModel(unittest.TestCase):
             self.pi,
             self.T,
             self.E,
+            desired_experiment_time=200,
+            prune_condition='time',
+            prune_boolean=True)
+        self.lineage3 = LineageTree(
+            self.pi,
+            self.T,
+            self.E,
             desired_experiment_time=500,
-            prune_condition='die',
-            prune_boolean=False)
+            prune_condition='both',
+            prune_boolean=True)
 
     def test_rvs(self):
         """ A unittest for random generator function, given the number of random variables we want from each distribution, that each corresponds to one of the observation types. """
@@ -107,6 +114,25 @@ class TestModel(unittest.TestCase):
         for cell in self.lineage.lineage_stats[1].full_lin_cells:
             if cell.obs[0] == 0:
                 self.assertTrue(die_prune_rule(cell))
+                
+    def test_time_prune_rule(self):
+        """ A unittest for the time_prune_rule. """
+
+        for cell in self.lineage3.lineage_stats[0].full_lin_cells:
+            if cell.time.endT > self.lineage3.desired_experiment_time:
+                self.assertTrue(time_prune_rule(cell,self.lineage3.desired_experiment_time))
+
+        for cell in self.lineage3.lineage_stats[1].full_lin_cells:
+            if cell.time.endT > self.lineage3.desired_experiment_time:
+                self.assertTrue(time_prune_rule(cell,self.lineage3.desired_experiment_time))
+                
+    def test_get_experiment_time(self):
+        """
+        A unittest for obtaining the experiment time.
+        """
+        experiment_time2 = get_experiment_time(self.lineage2)
+        experiment_time3 = get_experiment_time(self.lineage3)
+        self.assertLess(experiment_time2,experiment_time3)
 
     def test_bernoulli_estimator(self):
         """

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 import scipy.stats as sp
-from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, prune_rule, report_time, get_experiment_time
+from ..StateDistribution import StateDistribution, bernoulli_estimator, exponential_estimator, gamma_estimator, die_prune_rule, report_time, get_experiment_time
 from ..LineageTree import LineageTree
 
 

--- a/lineage/tests/test_tHMM.py
+++ b/lineage/tests/test_tHMM.py
@@ -35,9 +35,9 @@ class TestModel(unittest.TestCase):
         state_obj0 = StateDistribution(state0, bern_p0, gamma_a0, gamma_loc, gamma_scale0)
         state_obj1 = StateDistribution(state1, bern_p1, gamma_a1, gamma_loc, gamma_scale1)
         self.E = [state_obj0, state_obj1]
-        num = 2**7 - 1
         # Using an unpruned lineage to avoid unforseen issues
-        self.X = [LineageTree(pi, T, self.E, num, prune_boolean=False)]
+        self.X = [LineageTree(pi,T, self.E, desired_experiment_time=500, prune_condition='die',\
+                              prune_boolean=False)]
         tHMMobj = tHMM(self.X, numStates=2)  # build the tHMM class with X
 
         # Test cases below
@@ -55,8 +55,6 @@ class TestModel(unittest.TestCase):
         self.assertTrue(np.isfinite(new_LL_list_after[0]))
 
         self.assertGreater(LL_after[0], LL_before[0])
-
-        del _
 
     def test_init_paramlist(self):
         '''

--- a/lineage/tests/test_tHMM.py
+++ b/lineage/tests/test_tHMM.py
@@ -36,7 +36,7 @@ class TestModel(unittest.TestCase):
         state_obj1 = StateDistribution(state1, bern_p1, gamma_a1, gamma_loc, gamma_scale1)
         self.E = [state_obj0, state_obj1]
         # Using an unpruned lineage to avoid unforseen issues
-        self.X = [LineageTree(pi,T, self.E, desired_experiment_time=500, prune_condition='die',\
+        self.X = [LineageTree(pi, T, self.E, desired_experiment_time=500, prune_condition='die',
                               prune_boolean=False)]
         tHMMobj = tHMM(self.X, numStates=2)  # build the tHMM class with X
 


### PR DESCRIPTION
Lineages are now created by default with a number of cells equal to (2**11)-1 which is 2047 cells. This enables us to create lineages long past the experiment run time, which is now a input argument for lineage creation. That is to say, all unpruned lineages are always going to be 2047 cells long. Pruned lineages then can be pruned in 1 of 3 ways (or just not pruned at all):

**if `fate` is chosen: daughter subtrees of cells that die are excised.
if `time` is chosen: daughter subtrees of cells with `endT` greater than some desired experimental time are excised.
if `both` is chosen: both of the above prune rules are applied (`OR` statement).**

A `Time` class is now added which each cell now contains under `cell.time` which contains the `startT`, `endT`, and `lifetime`. It seemed appropriate to put the definition of the time related functions into the `StateDistribution` file. The use of the new functions (not the definition of) are in the `LineageTree` file. The `prune_boolean` and the `prune_condition` statement are now cleaner and easier to use.

Functions that dealt with time are now rewritten to accommodate this.

Old tests were removed and new tests were added.

Figure code has NOT yet been changed and WILL break. Will change in a later branch.