### PR TITLE
Upgrade.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 graphviz==0.13.2
 matplotlib==3.2.1
 networkx==2.4
-numpy==1.18.2
+numpy==1.18.3
 scipy==1.4.1
 seaborn==0.10.0
 scikit-learn
@@ -14,4 +14,4 @@ manubot==0.3.1
 pandoc-fignos==2.2.0
 pandoc-eqnos==2.1.1
 pandoc-tablenos==2.1.1
-numba==0.48.0
+numba==0.49.0


### PR DESCRIPTION
This might fix the deprecation? The imports are internal to numba, so there's nothing we can do in our code.