### PR TITLE
Add function for placing cartoons

### DIFF
--- a/lineage/figures/figureCommon.py
+++ b/lineage/figures/figureCommon.py
@@ -7,6 +7,7 @@ from cycler import cycler
 import numpy as np
 from matplotlib import gridspec, pyplot as plt
 import seaborn as sns
+import svgutils.transform as st
 from ..Analyze import run_Results_over, run_Analyze_over
 
 from ..states.StateDistribution import StateDistribution
@@ -123,6 +124,21 @@ def subplotLabel(axs):
     for ii, ax in enumerate(axs):
         ax.text(-0.2, 1.25, ascii_lowercase[ii], transform=ax.transAxes, fontsize=16, fontweight="bold", va="top")
 
+
+def overlayCartoon(figFile, cartoonFile, x, y, scalee=1, scale_x=1, scale_y=1):
+    """ Add cartoon to a figure file. """
+
+    # Overlay Figure cartoons
+    template = st.fromfile(figFile)
+    cartoon = st.fromfile(cartoonFile).getroot()
+
+    cartoon.moveto(x, y, scale=scalee)
+    cartoon.scale_xy(scale_x, scale_y)
+
+    template.append(cartoon)
+    template.save(figFile)
+        
+        
 
 def figureMaker(ax, x, paramEst, accuracies, tr, pii, paramTrues, xlabel="Number of Cells"):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy==1.18.4
 scipy==1.4.1
 seaborn==0.10.1
 scikit-learn==0.23.0
+svgutils==0.3.1
 Sphinx
 pytest==5.4.2
 sphinx-autoapi


### PR DESCRIPTION
Here is the function for placing cartoons within a figure. Note that this has to happen **after** saving the SVG file, and so the best place to use this is in the `genFigures.py` script as demonstrated [here](https://github.com/meyer-lab/gc-cytokines/blob/master/genFigures.py#L24).