### PR TITLE
Clean state interface

### DIFF
--- a/lineage/BaumWelch.py
+++ b/lineage/BaumWelch.py
@@ -71,7 +71,7 @@ def calculateQuantities(tHMMobj):
     return NF, betas, gammas, LL
 
 
-def fit(tHMMobj, tolerance=np.spacing(1), max_iter=200):
+def fit(tHMMobj, tolerance=np.spacing(1), max_iter=300):
     """Runs the tHMM function through Baum Welch fitting"""
     num_states = tHMMobj.num_states
 

--- a/lineage/BaumWelch.py
+++ b/lineage/BaumWelch.py
@@ -109,7 +109,7 @@ def fit(tHMMobj, tolerance=np.spacing(1), max_iter=200):
             all_cells = [cell.obs for lineage in tHMMobj.X for cell in lineage.output_lineage]
             all_gammas = np.vstack(gammas)
             for state_j in range(tHMMobj.num_states):
-                tHMMobj.estimate.E[state_j] = tHMMobj.estimate.E[state_j].estimator(all_cells, all_gammas[:, state_j])
+                tHMMobj.estimate.E[state_j].estimator(all_cells, all_gammas[:, state_j])
 
         tHMMobj.MSD = tHMMobj.get_Marginal_State_Distributions()
         tHMMobj.EL = tHMMobj.get_Emission_Likelihoods()

--- a/lineage/DownwardRecursion.py
+++ b/lineage/DownwardRecursion.py
@@ -38,7 +38,9 @@ def get_nonroot_gammas(tHMMobj, gammas, betas):
 
                     beta_parent = beta_parent_child_func(beta_array=betas[num], T=T, MSD_array=tHMMobj.MSD[num], node_child_n_idx=child_idx)
 
-                    sum_holder = np.matmul(gammas[num][parent_idx, :] / beta_parent, T)
+                    with np.errstate(divide="ignore", invalid="ignore"):
+                        sum_holder = np.matmul(gammas[num][parent_idx, :] / beta_parent, T)
+
                     gammas[num][child_idx, :] = coeffs[child_idx, :] * sum_holder
 
         assert np.all(gammas[num][0, :] == betas[num][0, :])

--- a/lineage/LineageTree.py
+++ b/lineage/LineageTree.py
@@ -58,7 +58,7 @@ class LineageTree:
 
         self.full_max_gen, self.full_list_of_gens = max_gen(self.full_lineage)
         self.full_leaves_idx, self.full_leaves = get_leaves(self.full_lineage)
-        if len(self.E[0].rvs(1)[0]) > 1:
+        if len(self.E[0].rvs(1)) > 1:
             assign_times(self)
 
         # Begin censoring:
@@ -123,6 +123,8 @@ class LineageTree:
         """
         cells_in_state = [cell for cell in self.full_lineage if cell.state == state]
         list_of_tuples_of_obs = self.E[state].rvs(size=len(cells_in_state))
+        list_of_tuples_of_obs = list(map(list, zip(*list_of_tuples_of_obs)))
+
         assert len(cells_in_state) == len(list_of_tuples_of_obs)
         for i, cell in enumerate(cells_in_state):
             cell.obs = list_of_tuples_of_obs[i]

--- a/lineage/states/StateDistPhase.py
+++ b/lineage/states/StateDistPhase.py
@@ -1,11 +1,7 @@
 """ State distribution class for separated G1 and G2 phase durations as observation. """
 import scipy.stats as sp
-<<<<<<< HEAD
+
 from .stateCommon import bern_pdf, bernoulli_estimator, gamma_pdf, gamma_estimator
-=======
-from .StateDistributionGamma import gamma_estimator
-from .stateCommon import bern_pdf, bernoulli_estimator, gamma_pdf
->>>>>>> master
 
 
 class StateDistribution2:
@@ -36,14 +32,8 @@ class StateDistribution2:
         # the individual observation likelihoods.
         bern_ll = bern_pdf(tuple_of_obs[0], self.params[0])
 
-        try:
-            gamma_llG1 = gamma_pdf(tuple_of_obs[1], self.params[1], self.params[2])
-        except ZeroDivisionError:
-            assert False, f"{tuple_of_obs[1]}, {self.params[1]}, {self.params[2]}"
-        try:
-            gamma_llG2 = gamma_pdf(tuple_of_obs[2], self.params[3], self.params[4])
-        except ZeroDivisionError:
-            assert False, f"{tuple_of_obs[2]}, {self.params[3]}, {self.params[4]}"
+        gamma_llG1 = gamma_pdf(tuple_of_obs[1], self.params[1], self.params[2])
+        gamma_llG2 = gamma_pdf(tuple_of_obs[2], self.params[3], self.params[4])
 
         return bern_ll * gamma_llG1 * gamma_llG2
 

--- a/lineage/states/StateDistPhase.py
+++ b/lineage/states/StateDistPhase.py
@@ -29,7 +29,7 @@ class StateDistribution2:
         # In our example, we assume the observation's are uncorrelated across the dimensions (across the different
         # distribution observations), so the likelihood of observing the multivariate observation is just the product of
         # the individual observation likelihoods.
-        bern_ll = bern_pdf(tuple_of_obs[0], self.bern_p)
+        bern_ll = bern_pdf(tuple_of_obs[0], self.params[0])
 
         try:
             gamma_llG1 = gamma_pdf(tuple_of_obs[1], self.params[1], self.params[2])

--- a/lineage/states/StateDistPhase.py
+++ b/lineage/states/StateDistPhase.py
@@ -1,21 +1,18 @@
 """ State distribution class for separated G1 and G2 phase durations as observation. """
-import numpy as np
 import scipy.stats as sp
-from .StateDistribution import gamma_estimator
-from .stateCommon import bern_pdf, bernoulli_estimator, gamma_pdf
+from .stateCommon import bern_pdf, bernoulli_estimator, gamma_pdf, gamma_estimator
 
 
 class StateDistribution2:
     """ For G1 and G2 separated as observations. """
 
-    def __init__(self, bern_p, gamma_a1, gamma_scale1, gamma_a2, gamma_scale2):  # user has to identify what parameters to use for each state
+    def __init__(self, bern_p=0.9, gamma_a1=7.0, gamma_scale1=3, gamma_a2=14.0, gamma_scale2=6):  # user has to identify what parameters to use for each state
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
         self.bern_p = bern_p
         self.gamma_a1 = gamma_a1
         self.gamma_scale1 = gamma_scale1
         self.gamma_a2 = gamma_a2
         self.gamma_scale2 = gamma_scale2
-        self.params = [self.bern_p, self.gamma_a1, self.gamma_scale1, self.gamma_a2, self.gamma_scale2]
 
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
@@ -63,7 +60,7 @@ class StateDistribution2:
             gamma_obsG2 = list(unzipped_list_of_tuples_of_obs[2])
             gamma_censor_obs = list(unzipped_list_of_tuples_of_obs[3])
         except BaseException:
-            self.tHMM_E_init()
+            return StateDistribution2()
 
         bern_p_estimate = bernoulli_estimator(bern_obs, gammas)
         gamma_a1_estimate, gamma_scale1_estimate = gamma_estimator(gamma_obsG1, gamma_censor_obs, gammas)
@@ -75,9 +72,3 @@ class StateDistribution2:
         # from estimation. This is then stored in the original state distribution object which then gets updated
         # if this function runs again.
         return state_estimate_obj
-
-    def tHMM_E_init(self):
-        """
-        Initialize a default state distribution.
-        """
-        return StateDistribution2(0.9, 7, 3 + (1 * (np.random.uniform())), 14, 6 + (1 * (np.random.uniform())))

--- a/lineage/states/StateDistPhase.py
+++ b/lineage/states/StateDistPhase.py
@@ -13,9 +13,9 @@ class StateDistribution2:
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
         # {
-        bern_obs = sp.bernoulli.rvs(p=self.bern_p, size=size)  # bernoulli observations
-        gamma_obsG1 = sp.gamma.rvs(a=self.gamma_a1, scale=self.gamma_scale1, size=size)  # gamma observations
-        gamma_obsG2 = sp.gamma.rvs(a=self.gamma_a2, scale=self.gamma_scale2, size=size)
+        bern_obs = sp.bernoulli.rvs(p=self.params[0], size=size)  # bernoulli observations
+        gamma_obsG1 = sp.gamma.rvs(a=self.params[1], scale=self.params[2], size=size)  # gamma observations
+        gamma_obsG2 = sp.gamma.rvs(a=self.params[3], scale=self.params[4], size=size)
         time_censor = [1] * (len(gamma_obsG1) + len(gamma_obsG2))
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
@@ -32,13 +32,13 @@ class StateDistribution2:
         bern_ll = bern_pdf(tuple_of_obs[0], self.bern_p)
 
         try:
-            gamma_llG1 = gamma_pdf(tuple_of_obs[1], self.gamma_a1, self.gamma_scale1)
+            gamma_llG1 = gamma_pdf(tuple_of_obs[1], self.params[1], self.params[2])
         except ZeroDivisionError:
-            assert False, f"{tuple_of_obs[1]}, {self.gamma_a1}, {self.gamma_scale1}"
+            assert False, f"{tuple_of_obs[1]}, {self.params[1]}, {self.params[2]}"
         try:
-            gamma_llG2 = gamma_pdf(tuple_of_obs[2], self.gamma_a2, self.gamma_scale2)
+            gamma_llG2 = gamma_pdf(tuple_of_obs[2], self.params[3], self.params[4])
         except ZeroDivisionError:
-            assert False, f"{tuple_of_obs[2]}, {self.gamma_a2}, {self.gamma_scale2}"
+            assert False, f"{tuple_of_obs[2]}, {self.params[3]}, {self.params[4]}"
 
         return bern_ll * gamma_llG1 * gamma_llG2
 

--- a/lineage/states/StateDistPhase.py
+++ b/lineage/states/StateDistPhase.py
@@ -8,11 +8,7 @@ class StateDistribution2:
 
     def __init__(self, bern_p=0.9, gamma_a1=7.0, gamma_scale1=3, gamma_a2=14.0, gamma_scale2=6):  # user has to identify what parameters to use for each state
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
-        self.bern_p = bern_p
-        self.gamma_a1 = gamma_a1
-        self.gamma_scale1 = gamma_scale1
-        self.gamma_a2 = gamma_a2
-        self.gamma_scale2 = gamma_scale2
+        self.params = [bern_p, gamma_a1, gamma_scale1, gamma_a2, gamma_scale2]
 
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
@@ -23,8 +19,7 @@ class StateDistribution2:
         time_censor = [1] * (len(gamma_obsG1) + len(gamma_obsG2))
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
-        list_of_tuple_of_obs = list(map(list, zip(bern_obs, gamma_obsG1, gamma_obsG2, time_censor)))
-        return list_of_tuple_of_obs
+        return list(map(list, zip(bern_obs, gamma_obsG1, gamma_obsG2, time_censor)))
 
     def pdf(self, tuple_of_obs):  # user has to define how to calculate the likelihood
         """ User-defined way of calculating the likelihood of the observation stored in a cell. """
@@ -60,15 +55,13 @@ class StateDistribution2:
             gamma_obsG2 = list(unzipped_list_of_tuples_of_obs[2])
             gamma_censor_obs = list(unzipped_list_of_tuples_of_obs[3])
         except BaseException:
-            return StateDistribution2()
+            self.params = [0.9, 7.0, 3, 14.0, 6]
+            return
 
-        bern_p_estimate = bernoulli_estimator(bern_obs, gammas)
-        gamma_a1_estimate, gamma_scale1_estimate = gamma_estimator(gamma_obsG1, gamma_censor_obs, gammas)
-        gamma_a2_estimate, gamma_scale2_estimate = gamma_estimator(gamma_obsG2, gamma_censor_obs, gammas)
-        state_estimate_obj = StateDistribution2(bern_p=bern_p_estimate, gamma_a1=gamma_a1_estimate, gamma_scale1=gamma_scale1_estimate, gamma_a2=gamma_a2_estimate, gamma_scale2=gamma_scale2_estimate)
-
+        self.params[0] = bernoulli_estimator(bern_obs, gammas)
+        self.params[1], self.params[2] = gamma_estimator(gamma_obsG1, gamma_censor_obs, gammas)
+        self.params[3], self.params[4] = gamma_estimator(gamma_obsG2, gamma_censor_obs, gammas)
         # } requires the user's attention.
         # Note that we return an instance of the state distribution class, but now instantiated with the parameters
         # from estimation. This is then stored in the original state distribution object which then gets updated
         # if this function runs again.
-        return state_estimate_obj

--- a/lineage/states/StateDistPhase.py
+++ b/lineage/states/StateDistPhase.py
@@ -19,7 +19,7 @@ class StateDistribution2:
         time_censor = [1] * (len(gamma_obsG1) + len(gamma_obsG2))
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
-        return list(map(list, zip(bern_obs, gamma_obsG1, gamma_obsG2, time_censor)))
+        return bern_obs, gamma_obsG1, gamma_obsG2, time_censor
 
     def pdf(self, tuple_of_obs):  # user has to define how to calculate the likelihood
         """ User-defined way of calculating the likelihood of the observation stored in a cell. """

--- a/lineage/states/StateDistribution.py
+++ b/lineage/states/StateDistribution.py
@@ -19,7 +19,7 @@ class StateDistribution:
         time_censor = [1] * len(gamma_obs)  # 1 if observed
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
-        return list(map(list, zip(bern_obs, gamma_obs, time_censor)))
+        return bern_obs, gamma_obs, time_censor
 
     def pdf(self, tuple_of_obs):  # user has to define how to calculate the likelihood
         """ User-defined way of calculating the likelihood of the observation stored in a cell. """

--- a/lineage/states/StateDistribution.py
+++ b/lineage/states/StateDistribution.py
@@ -1,20 +1,17 @@
 """ This file is completely user defined. We have provided a general starting point for the user to use as an example. """
 import numpy as np
 import scipy.stats as sp
-import scipy.special as sc
-from scipy.optimize import brentq
 
 
-from .stateCommon import bern_pdf, gamma_pdf, bernoulli_estimator
+from .stateCommon import bern_pdf, gamma_pdf, bernoulli_estimator, gamma_estimator
 
 
 class StateDistribution:
-    def __init__(self, bern_p, gamma_a, gamma_scale):
+    def __init__(self, bern_p=0.9, gamma_a=7, gamma_scale=3):
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
         self.bern_p = bern_p
         self.gamma_a = gamma_a
         self.gamma_scale = gamma_scale
-        self.params = [self.bern_p, self.gamma_a, self.gamma_scale]
 
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
@@ -61,7 +58,7 @@ class StateDistribution:
             γ_obs = np.array(unzipped_list_of_tuples_of_obs[1])
             γ_censor_obs = np.array(unzipped_list_of_tuples_of_obs[2], dtype=bool)
         except BaseException:
-            return self.tHMM_E_init()
+            return StateDistribution()
 
         bern_p_estimate = bernoulli_estimator(bern_obs, gammas)
         γ_a_hat, γ_scale_hat = gamma_estimator(γ_obs, γ_censor_obs, gammas)
@@ -71,51 +68,3 @@ class StateDistribution:
         # Note that we return an instance of the state distribution class, but now instantiated with the parameters
         # from estimation. This is then stored in the original state distribution object which then gets updated
         # if this function runs again.
-
-    def tHMM_E_init(self):
-        """ Initialize a default state distribution. """
-        return StateDistribution(0.9, 7, 3 + (1 * (np.random.uniform())))
-
-
-# Because parameter estimation requires that estimators be written or imported,
-# the user should be able to provide
-# estimators that can solve for the parameters that describe the distributions.
-# We provide some estimators below as an example.
-# Their use in the StateDistribution class is shown in the estimator class method.
-# User must take care to define estimators that
-# can handle the case where the list of observations is empty.
-
-
-def gamma_estimator(gamma_obs, gamma_censor_obs, gammas):
-    """
-    This is a closed-form estimator for two parameters
-    of the Gamma distribution, which is corrected for bias.
-    """
-    gammaCor = sum(gammas * gamma_obs) / sum(gammas)
-    s = np.log(gammaCor) - sum(gammas * np.log(gamma_obs)) / sum(gammas)
-    def f(k): return np.log(k) - sc.polygamma(0, k) - s
-
-    if f(0.01) * f(100.0) > 0.0:
-        a_hat = 10.0
-    else:
-        a_hat = brentq(f, 0.01, 100.0)
-
-    scale_hat = gammaCor / a_hat
-
-    def LL(x):
-        uncens = sp.gamma.logpdf(gamma_obs, a=x[0], scale=x[1])
-        cens = sp.gamma.logsf(gamma_obs, a=x[0], scale=x[1])
-
-        # If the observation was censored, use the survival function
-        uncens[np.logical_not(gamma_censor_obs)] = cens[np.logical_not(gamma_censor_obs)]
-
-        # If gamma indicates the cell is very unlikely for this state, ignore it
-        gamL = np.log(gammas)
-        uncens[gamL < -9] = 1.0
-        gamL[gamL < -9] = 0
-
-        return -np.sum(uncens + gamL)
-
-    # res = minimize(LL, [a_hat, scale_hat])
-
-    return a_hat, scale_hat

--- a/lineage/states/StateDistribution1.py
+++ b/lineage/states/StateDistribution1.py
@@ -7,11 +7,10 @@ from .stateCommon import bern_pdf, bernoulli_estimator
 
 
 class StateDistribution:
-    def __init__(self, bern_p, exp_beta):
+    def __init__(self, bern_p=0.9, exp_beta=7.0):
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
         self.bern_p = bern_p
         self.exp_beta = exp_beta
-        self.params = [self.bern_p, self.exp_beta]
 
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
@@ -49,23 +48,16 @@ class StateDistribution:
             exp_obs = list(unzipped_list_of_tuples_of_obs[1])
             time_censor_obs = list(unzipped_list_of_tuples_of_obs[2])
         except BaseException:
-            return self.tHMM_E_init()
+            return StateDistribution()
 
         bern_p_estimate = bernoulli_estimator(bern_obs, gammas)
         exp_beta_estimate = exp_estimator(exp_obs, time_censor_obs, gammas)
 
-        state_estimate_obj = StateDistribution(bern_p=bern_p_estimate, exp_beta=exp_beta_estimate)
+        return StateDistribution(bern_p=bern_p_estimate, exp_beta=exp_beta_estimate)
         # } requires the user's attention.
         # Note that we return an instance of the state distribution class, but now instantiated with the parameters
         # from estimation. This is then stored in the original state distribution object which then gets updated
         # if this function runs again.
-        return state_estimate_obj
-
-    def tHMM_E_init(self):
-        """
-        Initialize a random state distribution.
-        """
-        return StateDistribution(0.9, 7 * (np.random.uniform()))
 
 
 # Because parameter estimation requires that estimators be written or imported,

--- a/lineage/states/StateDistribution1.py
+++ b/lineage/states/StateDistribution1.py
@@ -19,7 +19,7 @@ class StateDistribution:
         time_censor = [1] * len(exp_obs)  # 1 if observed
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
-        return list(map(list, zip(bern_obs, exp_obs, time_censor)))
+        return bern_obs, exp_obs, time_censor
 
     def pdf(self, tuple_of_obs):  # user has to define how to calculate the likelihood
         """ User-defined way of calculating the likelihood of the observation stored in a cell. """

--- a/lineage/states/StateDistribution1.py
+++ b/lineage/states/StateDistribution1.py
@@ -9,19 +9,17 @@ from .stateCommon import bern_pdf, bernoulli_estimator
 class StateDistribution:
     def __init__(self, bern_p=0.9, exp_beta=7.0):
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
-        self.bern_p = bern_p
-        self.exp_beta = exp_beta
+        self.params = [bern_p, exp_beta]
 
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
         # {
-        bern_obs = sp.bernoulli.rvs(p=self.bern_p, size=size)  # bernoulli observations
-        exp_obs = sp.expon.rvs(scale=self.exp_beta, size=size)  # gamma observations
+        bern_obs = sp.bernoulli.rvs(p=self.params[0], size=size)  # bernoulli observations
+        exp_obs = sp.expon.rvs(scale=self.params[1], size=size)  # gamma observations
         time_censor = [1] * len(exp_obs)  # 1 if observed
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
-        list_of_tuple_of_obs = list(map(list, zip(bern_obs, exp_obs, time_censor)))
-        return list_of_tuple_of_obs
+        return list(map(list, zip(bern_obs, exp_obs, time_censor)))
 
     def pdf(self, tuple_of_obs):  # user has to define how to calculate the likelihood
         """ User-defined way of calculating the likelihood of the observation stored in a cell. """
@@ -32,8 +30,8 @@ class StateDistribution:
         # distribution observations), so the likelihood of observing the multivariate observation is just the product of
         # the individual observation likelihoods.
 
-        bern_ll = bern_pdf(tuple_of_obs[0], self.bern_p)
-        exp_ll = exp_pdf(tuple_of_obs[1], self.exp_beta)
+        bern_ll = bern_pdf(tuple_of_obs[0], self.params[0])
+        exp_ll = exp_pdf(tuple_of_obs[1], self.params[1])
         return bern_ll * exp_ll
 
     def estimator(self, list_of_tuples_of_obs, gammas):
@@ -48,12 +46,11 @@ class StateDistribution:
             exp_obs = list(unzipped_list_of_tuples_of_obs[1])
             time_censor_obs = list(unzipped_list_of_tuples_of_obs[2])
         except BaseException:
-            return StateDistribution()
+            self.params = [0.9, 7.0]
+            return
 
-        bern_p_estimate = bernoulli_estimator(bern_obs, gammas)
-        exp_beta_estimate = exp_estimator(exp_obs, time_censor_obs, gammas)
-
-        return StateDistribution(bern_p=bern_p_estimate, exp_beta=exp_beta_estimate)
+        self.params[0] = bernoulli_estimator(bern_obs, gammas)
+        self.params[1] = exp_estimator(exp_obs, time_censor_obs, gammas)
         # } requires the user's attention.
         # Note that we return an instance of the state distribution class, but now instantiated with the parameters
         # from estimation. This is then stored in the original state distribution object which then gets updated

--- a/lineage/states/StateDistributionGamma.py
+++ b/lineage/states/StateDistributionGamma.py
@@ -32,14 +32,10 @@ class StateDistribution:
 
         bern_ll = bern_pdf(tuple_of_obs[0], self.params[0]) if tuple_of_obs[2] == 1 else 1.0
 
-        try:
-            if tuple_of_obs[2] == 1:
-                gamma_ll = gamma_pdf(tuple_of_obs[1], self.params[1], self.params[2])
-            else:
-                gamma_ll = sp.gamma.sf(tuple_of_obs[1], a=self.params[1], scale=self.params[2])
-        except ZeroDivisionError:
-            print(f"{tuple_of_obs[1]}, {self.params[1]}, {self.params[2]}")
-            raise
+        if tuple_of_obs[2] == 1:
+            gamma_ll = gamma_pdf(tuple_of_obs[1], self.params[1], self.params[2])
+        else:
+            gamma_ll = sp.gamma.sf(tuple_of_obs[1], a=self.params[1], scale=self.params[2])
 
         return bern_ll * gamma_ll
 

--- a/lineage/states/StateDistributionGamma.py
+++ b/lineage/states/StateDistributionGamma.py
@@ -7,7 +7,7 @@ from .stateCommon import bern_pdf, gamma_pdf, bernoulli_estimator, gamma_estimat
 
 
 class StateDistribution:
-    def __init__(self, bern_p=0.9, gamma_a=7, gamma_scale=3):
+    def __init__(self, bern_p=0.9, gamma_a=7, gamma_scale=4.5):
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
         self.params = [bern_p, gamma_a, gamma_scale]
 

--- a/lineage/states/StateDistributionGaussian.py
+++ b/lineage/states/StateDistributionGaussian.py
@@ -4,22 +4,19 @@ import scipy.stats as sp
 
 
 class StateDistribution:
-    def __init__(self, norm_loc, norm_scale):
+    def __init__(self, norm_loc=10.0, norm_scale=1.0):
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
         self.norm_loc = norm_loc
-        assert norm_scale > 0, "A non-valid scale has been given. Please provide a scale > 0"
+        assert norm_scale > 0
         self.norm_scale = norm_scale
-        self.params = [self.norm_loc, self.norm_scale]
 
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
         # {
         norm_obs = sp.norm.rvs(loc=self.norm_loc, scale=self.norm_scale, size=size)  # normal observations
-        # time_censor = [1] * len(gamma_obs)  # 1 if observed
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
-        list_of_tuple_of_obs = list(map(list, zip(norm_obs)))
-        return list_of_tuple_of_obs
+        return list(map(list, zip(norm_obs)))
 
     def pdf(self, tuple_of_obs):  # user has to define how to calculate the likelihood
         """ User-defined way of calculating the likelihood of the observation stored in a cell. """
@@ -29,10 +26,7 @@ class StateDistribution:
         # In our example, we assume the observation's are uncorrelated across the dimensions (across the different
         # distribution observations), so the likelihood of observing the multivariate observation is just the product of
         # the individual observation likelihoods.
-
-        norm_ll = sp.norm.pdf(tuple_of_obs[0], self.norm_loc, self.norm_scale)
-
-        return norm_ll
+        return sp.norm.pdf(tuple_of_obs[0], self.norm_loc, self.norm_scale)
 
     def estimator(self, list_of_tuples_of_obs, gammas):
         """ User-defined way of estimating the parameters given a list of the tuples of observations from a group of cells. """
@@ -44,41 +38,14 @@ class StateDistribution:
         try:
             norm_obs = list(unzipped_list_of_tuples_of_obs[0])
         except BaseException:
-            self.tHMM_E_init()
+            return StateDistribution()
 
-        norm_loc_estimate, norm_scale_estimate = norm_estimator(norm_obs, gammas)
-
-        state_estimate_obj = StateDistribution(norm_loc=norm_loc_estimate, norm_scale=norm_scale_estimate)
+        eps = np.finfo(float).eps
+        mu = (sum(gammas * norm_obs) + eps) / (sum(gammas) + eps)
+        norm_scale_estimate = ((sum(gammas * (norm_obs - mu) ** 2) + eps) / (sum(gammas) + eps)) ** 0.5
+        
+        return StateDistribution(norm_loc=mu, norm_scale=norm_scale_estimate)
         # } requires the user's attention.
         # Note that we return an instance of the state distribution class, but now instantiated with the parameters
         # from estimation. This is then stored in the original state distribution object which then gets updated
         # if this function runs again.
-        return state_estimate_obj
-
-    def tHMM_E_init(self):
-        """
-        Initialize a default state distribution.
-        """
-        return StateDistribution(10, 1 + 10 * (np.random.uniform()))
-
-
-# Because parameter estimation requires that estimators be written or imported,
-# the user should be able to provide
-# estimators that can solve for the parameters that describe the distributions.
-# We provide some estimators below as an example.
-# Their use in the StateDistribution class is shown in the estimator class method.
-# User must take care to define estimators that
-# can handle the case where the list of observations is empty.
-
-
-def norm_estimator(norm_obs, gammas):
-    """This function is an estimator for the mean and standard deviation of a normal distribution, including weighting for each state"""
-    mu = (sum(gammas * norm_obs) + 1e-10) / (sum(gammas) + 1e-10)
-    std = ((sum(gammas * (norm_obs - mu) ** 2) + 1e-10) / (sum(gammas) + 1e-10)) ** 0.5
-    if mu == 0:
-        print("mu == 0")
-    if std == 0:
-        print("std == 0")
-    if sum(gammas) == 0:
-        print("sum(gammas) == 0")
-    return mu, std

--- a/lineage/states/StateDistributionGaussian.py
+++ b/lineage/states/StateDistributionGaussian.py
@@ -6,14 +6,13 @@ import scipy.stats as sp
 class StateDistribution:
     def __init__(self, norm_loc=10.0, norm_scale=1.0):
         """ Initialization function should take in just in the parameters for the observations that comprise the multivariate random variable emission they expect their data to have. """
-        self.norm_loc = norm_loc
         assert norm_scale > 0
-        self.norm_scale = norm_scale
+        self.params = [norm_loc, norm_scale]
 
     def rvs(self, size):  # user has to identify what the multivariate (or univariate if he or she so chooses) random variable looks like
         """ User-defined way of calculating a random variable given the parameters of the state stored in that observation's object. """
         # {
-        norm_obs = sp.norm.rvs(loc=self.norm_loc, scale=self.norm_scale, size=size)  # normal observations
+        norm_obs = sp.norm.rvs(loc=self.params[0], scale=self.params[1], size=size)  # normal observations
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
         return list(map(list, zip(norm_obs)))
@@ -26,7 +25,7 @@ class StateDistribution:
         # In our example, we assume the observation's are uncorrelated across the dimensions (across the different
         # distribution observations), so the likelihood of observing the multivariate observation is just the product of
         # the individual observation likelihoods.
-        return sp.norm.pdf(tuple_of_obs[0], self.norm_loc, self.norm_scale)
+        return sp.norm.pdf(tuple_of_obs[0], self.params[0], self.params[1])
 
     def estimator(self, list_of_tuples_of_obs, gammas):
         """ User-defined way of estimating the parameters given a list of the tuples of observations from a group of cells. """
@@ -38,13 +37,12 @@ class StateDistribution:
         try:
             norm_obs = list(unzipped_list_of_tuples_of_obs[0])
         except BaseException:
-            return StateDistribution()
+            self.params = [10.0, 1.0]
+            return
 
         eps = np.finfo(float).eps
-        mu = (sum(gammas * norm_obs) + eps) / (sum(gammas) + eps)
-        norm_scale_estimate = ((sum(gammas * (norm_obs - mu) ** 2) + eps) / (sum(gammas) + eps)) ** 0.5
-        
-        return StateDistribution(norm_loc=mu, norm_scale=norm_scale_estimate)
+        self.params[0] = (sum(gammas * norm_obs) + eps) / (sum(gammas) + eps)
+        self.params[1] = ((sum(gammas * (norm_obs - self.params[0]) ** 2) + eps) / (sum(gammas) + eps)) ** 0.5
         # } requires the user's attention.
         # Note that we return an instance of the state distribution class, but now instantiated with the parameters
         # from estimation. This is then stored in the original state distribution object which then gets updated

--- a/lineage/states/StateDistributionGaussian.py
+++ b/lineage/states/StateDistributionGaussian.py
@@ -15,7 +15,7 @@ class StateDistribution:
         norm_obs = sp.norm.rvs(loc=self.params[0], scale=self.params[1], size=size)  # normal observations
         # } is user-defined in that they have to define and maintain the order of the multivariate random variables.
         # These tuples of observations will go into the cells in the lineage tree.
-        return list(map(list, zip(norm_obs)))
+        return (norm_obs, )
 
     def pdf(self, tuple_of_obs):  # user has to define how to calculate the likelihood
         """ User-defined way of calculating the likelihood of the observation stored in a cell. """

--- a/lineage/states/stateCommon.py
+++ b/lineage/states/stateCommon.py
@@ -3,6 +3,9 @@
 from math import gamma
 import numpy as np
 from numba import njit
+import scipy.stats as sp
+import scipy.special as sc
+from scipy.optimize import brentq
 
 
 @njit
@@ -25,6 +28,41 @@ def gamma_pdf(x, a, scale):
     probability distribution function.
     """
     return x ** (a - 1.0) * np.exp(-1.0 * x / scale) / gamma(a) / (scale ** a)
+
+
+def gamma_estimator(gamma_obs, gamma_censor_obs, gammas):
+    """
+    This is a weighted, closed-form estimator for two parameters
+    of the Gamma distribution.
+    """
+    gammaCor = sum(gammas * gamma_obs) / sum(gammas)
+    s = np.log(gammaCor) - sum(gammas * np.log(gamma_obs)) / sum(gammas)
+    def f(k): return np.log(k) - sc.polygamma(0, k) - s
+
+    if f(0.01) * f(100.0) > 0.0:
+        a_hat = 10.0
+    else:
+        a_hat = brentq(f, 0.01, 100.0)
+
+    scale_hat = gammaCor / a_hat
+
+    def LL(x):
+        uncens = sp.gamma.logpdf(gamma_obs, a=x[0], scale=x[1])
+        cens = sp.gamma.logsf(gamma_obs, a=x[0], scale=x[1])
+
+        # If the observation was censored, use the survival function
+        uncens[np.logical_not(gamma_censor_obs)] = cens[np.logical_not(gamma_censor_obs)]
+
+        # If gamma indicates the cell is very unlikely for this state, ignore it
+        gamL = np.log(gammas)
+        uncens[gamL < -9] = 1.0
+        gamL[gamL < -9] = 0
+
+        return -np.sum(uncens + gamL)
+
+    # res = minimize(LL, [a_hat, scale_hat])
+
+    return a_hat, scale_hat
 
 
 def bernoulli_estimator(bern_obs, gammas):

--- a/lineage/tHMM.py
+++ b/lineage/tHMM.py
@@ -1,5 +1,6 @@
 """ This file holds the parameters of our tHMM in the tHMM class. """
 
+from copy import deepcopy
 import numpy as np
 
 
@@ -17,7 +18,7 @@ class estimate:
             self.T = self.fT
         self.E = []
         for _ in range(self.num_states):
-            self.E.append(X[0].E[0].tHMM_E_init())
+            self.E.append(deepcopy(X[0].E[0]))
         if self.fE is not None:
             self.E = self.fE
 

--- a/lineage/tHMM.py
+++ b/lineage/tHMM.py
@@ -1,6 +1,5 @@
 """ This file holds the parameters of our tHMM in the tHMM class. """
 
-from copy import deepcopy
 import numpy as np
 
 
@@ -18,7 +17,7 @@ class estimate:
             self.T = self.fT
         self.E = []
         for _ in range(self.num_states):
-            self.E.append(deepcopy(X[0].E[0]))
+            self.E.append(X[0].E[0].__class__())
         if self.fE is not None:
             self.E = self.fE
 

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -41,12 +41,10 @@ class TestModel(unittest.TestCase):
         given the number of random variables we want from each distribution,
         that each corresponds to one of the observation types
         """
-        tuple_of_obs = self.E[0].rvs(size=30)
-        bern_obs, gamma_obs, _ = list(zip(*tuple_of_obs))
+        bern_obs, gamma_obs, _ = self.E[0].rvs(size=30)
         self.assertTrue(len(bern_obs) == len(gamma_obs) == 30)
 
-        tuple_of_obs1 = self.E[1].rvs(size=40)
-        bern_obs1, gamma_obs1, _ = list(zip(*tuple_of_obs1))
+        bern_obs1, gamma_obs1, _ = self.E[1].rvs(size=40)
         self.assertTrue(len(bern_obs1) == len(gamma_obs1) == 40)
 
     def test_pdf(self):
@@ -56,15 +54,15 @@ class TestModel(unittest.TestCase):
         (the size == 1 which mean we just have one bernoulli, and one gamma).
         """
         # for stateDist0
-        list_of_tuple_of_obs = self.E[0].rvs(size=1)
-        tuple_of_obs = list_of_tuple_of_obs[0]
-        likelihood = self.E[0].pdf(tuple_of_obs)
+        bobs = self.E[0].rvs(size=1)
+        bobs = (bobs[0][0], bobs[1][0], bobs[2][0])
+        likelihood = self.E[0].pdf(bobs)
         self.assertTrue(0.0 <= likelihood <= 1.0)
 
         # for stateDist1
-        list_of_tuple_of_obs1 = self.E[1].rvs(size=1)
-        tuple_of_obs1 = list_of_tuple_of_obs1[0]
-        likelihood1 = self.E[1].pdf(tuple_of_obs1)
+        bobs = self.E[1].rvs(size=1)
+        bobs = (bobs[0][0], bobs[1][0], bobs[2][0])
+        likelihood1 = self.E[1].pdf(bobs)
         self.assertTrue(0.0 <= likelihood1 <= 1.0)
 
     def test_estimator(self):
@@ -72,6 +70,7 @@ class TestModel(unittest.TestCase):
         A unittest for the estimator function, by generating 150 observatopns for each of the
         distribution functions, we use the estimator and compare. """
         tuples_of_obs = self.E[0].rvs(size=3000)
+        tuples_of_obs = list(map(list, zip(*tuples_of_obs)))
         gammas = np.array([1] * len(tuples_of_obs))
         estimator_obj = deepcopy(self.E[0])
         estimator_obj.estimator(tuples_of_obs, gammas)

--- a/lineage/tests/test_StateDistribution.py
+++ b/lineage/tests/test_StateDistribution.py
@@ -1,5 +1,6 @@
 """ Unit test file. """
 import unittest
+from copy import deepcopy
 import numpy as np
 import scipy.stats as sp
 from ..states.StateDistribution import (
@@ -72,12 +73,13 @@ class TestModel(unittest.TestCase):
         distribution functions, we use the estimator and compare. """
         tuples_of_obs = self.E[0].rvs(size=3000)
         gammas = np.array([1] * len(tuples_of_obs))
-        estimator_obj = self.E[0].estimator(tuples_of_obs, gammas)
+        estimator_obj = deepcopy(self.E[0])
+        estimator_obj.estimator(tuples_of_obs, gammas)
 
         # here we check the estimated parameters to be close
-        self.assertTrue(0.0 <= abs(estimator_obj.bern_p - self.E[0].bern_p) <= 0.1)
-        self.assertTrue(0.0 <= abs(estimator_obj.gamma_a - self.E[0].gamma_a) <= 3.0)
-        self.assertTrue(0.0 <= abs(estimator_obj.gamma_scale - self.E[0].gamma_scale) <= 3.0)
+        self.assertTrue(0.0 <= abs(estimator_obj.params[0] - self.E[0].params[0]) <= 0.1)
+        self.assertTrue(0.0 <= abs(estimator_obj.params[1] - self.E[0].params[1]) <= 3.0)
+        self.assertTrue(0.0 <= abs(estimator_obj.params[2] - self.E[0].params[2]) <= 3.0)
 
     def test_censor(self):
         """


### PR DESCRIPTION
This has the state distributions update in-place, and stores the parameters only in the `params` vector, rather than in two places. Finally, this moves the zip/list/map/list step outside of the StateDistribution, so that the interface is cleaner.